### PR TITLE
Command property accepts arrays

### DIFF
--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -8,43 +8,53 @@
  * MIT License
  */
 module.exports = function( grunt ) {
-	'use strict';
+    'use strict';
 
-	var _ = grunt.utils._;
-	var log = grunt.log;
+    var _ = grunt.utils._;
+    var log = grunt.log;
 
-	grunt.registerMultiTask( 'shell', 'Run shell commands', function() {
-		var exec = require('child_process').exec;
-		var done = this.async();
-		var data = _.extend( [], grunt.config.get('shell')._options, this.data );
-		var dataOut = data.stdout;
-		var dataErr = data.stderr;
+    grunt.registerMultiTask( 'shell', 'Run shell commands', function() {
+        var exec = require('child_process').exec;
+        var done = this.async();
+        var data = _.extend( [], grunt.config.get('shell')._options, this.data );
+        var dataOut = data.stdout;
+        var dataErr = data.stderr;
 
-		if ( _.isFunction( data.callback ) ) {
-			data.callback.call( this );
-			return;
-		}
+        if ( _.isFunction( data.callback ) ) {
+            data.callback.call( this );
+            return;
+        }
+ 
+        if (data.command instanceof Array) {
+            for (var i = 0; i < data.command.length; i++) {
+                execute(data.command[i]);
+            }            
+        } else {
+            execute(data.command);
+        }
 
-		exec( data.command, data.execOptions, function( err, stdout, stderr ) {
-			if ( stdout ) {
-				if ( _.isFunction( dataOut ) ) {
-					dataOut( stdout );
-				} else if ( dataOut === true ) {
-					log.write( stdout );
-				}
-			}
+        function execute(command) {
+            exec( command, data.execOptions, function( err, stdout, stderr ) {
+                if ( stdout ) {
+                    if ( _.isFunction( dataOut ) ) {
+                        dataOut( stdout );
+                    } else if ( dataOut === true ) {
+                        log.write( stdout );
+                    }
+                }
 
-			if ( err ) {
-				if ( _.isFunction( dataErr ) ) {
-					dataErr( stderr );
-				} else if ( data.failOnError === true ) {
-					grunt.fatal( err );
-				} else if ( dataErr === true ) {
-					log.error( err );
-				}
-			}
+                if ( err ) {
+                    if ( _.isFunction( dataErr ) ) {
+                        dataErr( stderr );
+                    } else if ( data.failOnError === true ) {
+                        grunt.fatal( err );
+                    } else if ( dataErr === true ) {
+                        log.error( err );
+                    }
+                }
 
-			done();
-		});
-	});
+                done();
+            });
+        }
+    });
 };


### PR DESCRIPTION
The current implementation only allows for one command string. This change checks for an array and executes the elements in order. For example:

```
shell: {
    dist_create_dirs: {
        command: [
            "mkdir examples",
            "mkdir examples/static",
            "mkdir examples/static/img",
            "mkdir examples/static/css",
            "mkdir examples/static/js",
            "mkdir examples/static/fonts"]
    }
}
```
