### PR TITLE
grunt.template.process on shell command

### DIFF
--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -25,6 +25,10 @@ module.exports = function( grunt ) {
 			return;
 		}
 
+        if (data.process) {
+            data.command = grunt.template.process(data.command,grunt.config());
+        }
+
 		exec( data.command, data.execOptions, function( err, stdout, stderr ) {
 			if ( stdout ) {
 				if ( _.isFunction( dataOut ) ) {


### PR DESCRIPTION
Hi,

I added a 'process' configuration, if set to true the 'command' will be processed as a grunt.template with the entire configuration object as argument.

ex.

grunt.initConfig({
    vars: {
        version: '0.1'  
    },
    shell: {
        command: 'echo "<%= vars.version =>"',
        stdout: true,
        process: true  
    }
});

We use it and it would be nice if you would like to include it as well!

thx
/david
