### PR TITLE
Remove grunt.utils._

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
 	"devDependencies": {
 		"grunt": "~0.3.12"
 	},
+	"dependencies": {
+		"underscore": "~1.4.3"
+	},
 	"engines": {
 		"node": ">=0.8.0"
 	},

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -10,7 +10,7 @@
 module.exports = function( grunt ) {
 	'use strict';
 
-	var _ = grunt.utils._;
+	var _ = require('underscore');
 	var log = grunt.log;
 
 	grunt.registerMultiTask( 'shell', 'Run shell commands', function() {


### PR DESCRIPTION
Hi, I want to use grunt-shell on grunt version `0.4.0rc4`, but It can not run because `grunt.utils._` is `undefined`. So I removed it.

Would you review it?

Thanks :)
