### PR TITLE
Stdout function needs a param for receiving the input

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,8 +68,8 @@ shell: {
 Do whatever you want with the stdout.
 
 ```javascript
-function log( input ) {
-	console.log( input );
+function log( stdout ) {
+	console.log( stdout );
 }
 
 ...


### PR DESCRIPTION
After a few tries trying to use stdout with a custom function, I got it this little mistake in the Wiki: the stdout function needs an input param. I've only tested in Windows, maybe it works the way it was in the Wiki in others OS.
