### PR TITLE
fix : with failOnError true, exit code is still 0 after error

### DIFF
--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -16,7 +16,7 @@ module.exports = function (grunt) {
 				options.callback.call(this, err, stdout, stderr, cb);
 			} else {
 				if (err && options.failOnError) {
-					grunt.warn(err);
+					grunt.fail.warn(err);
 				}
 				cb();
 			}


### PR DESCRIPTION
Hi,

I'm using this plugin to run PHPUnit in a grunt task fired by a git pre-commit hook, and need the hook to fail if phpUnit fails. Currently even with failOnError set to true, the error code returned from grunt after a failed and aborted run is 0. This fix makes the task die spectacularly on fail and reports a non zero error code back to the shell.

Cheers,
Adam
