### PR TITLE
When the command is a function, call it to get the executable command.

### DIFF
--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -10,7 +10,14 @@ module.exports = function (grunt) {
 			stderr: false,
 			failOnError: false
 		});
-		var cmd = grunt.template.process(this.data.command);
+
+		var command = this.data.command;
+		if(typeof this.data.command === 'function'){
+			command = this.data.command(this);
+		}
+
+		var cmd = grunt.template.process(command);
+
 		var cp = exec(cmd, options.execOptions, function (err, stdout, stderr) {
 			if (_.isFunction(options.callback)) {
 				options.callback.call(this, err, stdout, stderr, cb);


### PR DESCRIPTION
If a function is provided for `command`, call that function passing in the reference to the running grunt-shell task. This allows for more flexible multi-step scripts to run, passing data from the output of one to the next, using a closured object.
### Example Usage

This example runs an ant script, that needs various AWS credentials, which it reads from the command line in the first grunt-shell task, then uses in the second.

``` javascript

/*global module:false*/
module.exports = function(grunt) {
    'use strict'
    var aws_id;
    var aws_secret;
    var fs = require('fs');

    /**
     * Get access info for AWS
     */
    function grabEnvVars(err, stdout, stderr, cb){
        var vals = stdout.split("\n");
        aws_id = vals[1].split("= ")[1];
        aws_secret = vals[2].split("= ")[1];
        cb();
    }

    /**
     * Create the command to run Ant with credentials.
     * With grabEnvVars, the id and secret are in the closure.
     */
    function getRepFiles(){
        var rep_files = fs.readdirSync('/list/of/rep/files');
        var output = rep_files.map(function(file){
            // Set vars that Ant will use.
            var env_vars = 'AWS_ACCESS_KEY_ID='+aws_id+' AWS_SECRET_ACCESS_KEY='+aws_secret+' ';
            return env_vars + 'ant -buildfile ./path/to/build.xml -Dlog.level=INFO -Drep.file='+file;
        }).join(' && ');
        return output;
    }

    grunt.initConfig({
        shell: {
            // Call the grabEnvVars to load into the closure scope.
            setUpEnv: {
                command: 'gpg --decrypt /var/some/keyfile | grep "personalization.dev.writer"',
                options: {
                    callback: grabEnvVars,
                    failOnError: true
                }
            },
            // Using the setUpEnv task that loaded the variables, use getRepFiles.
            woth: {
                command: getRepFiles,
                options: {
                    stdout: true,
                    stderr: true,
                    failOnError: true
                }
            }
        }       
    });

    grunt.loadNpmTasks('grunt-shell');

    grunt.registerTask('default', ['shell:setUpEnv', 'shell:woth']);
};
```
