### PR TITLE
Allow command function to accept arguments

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,10 +18,10 @@ module.exports = function (grunt) {
 				}
 			},
 			fnCmd: {
-				command: function (ver) {
+				command: function (version) {
 					// `this` is scoped to the grunt instance
-					if(ver){
-						return 'echo grunt-shell version: ' + ver;
+					if (version) {
+						return 'echo grunt-shell version: ' + version;
 					} else {
 						return 'echo grunt version: ' + this.version
 					}

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ grunt.initConfig({
 ```
 Which can also take arguments:
 
-```javascript
+```js
 shell: {
 	makeDir: {
 		command: function (greeting) {
@@ -100,6 +100,9 @@ shell: {
 		}
 	}
 }
+
+grunt.loadNpmTasks('grunt-shell');
+grunt.registerTask('default', ['shell:hello']);
 ```
 
 

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -17,7 +17,7 @@ module.exports = function (grunt) {
 			throw new Error('`command` is required.');
 		}
 
-		cmd = grunt.template.process(_.isFunction(cmd) ? cmd.apply(grunt,arguments) : cmd);
+		cmd = grunt.template.process(_.isFunction(cmd) ? cmd.apply(grunt, arguments) : cmd);
 
 		var cp = exec(cmd, options.execOptions, function (err, stdout, stderr) {
 			if (_.isFunction(options.callback)) {


### PR DESCRIPTION
I ran into a situation where it was useful to create a command string based on arguments, e.g.:

```
shell: {
  someTask: {
    command: function(myArg){
      return 'command ' + myArg;
    }
  }
}

# grunt shell:someTask:foo
```

Which would run <code>command foo</code>

I anticipate such a feature may be useful for others as well (and selfishly I'd like this feature to be in the npm package version ;)
