### PR TITLE
Honor grunt --no-color in child process output

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,6 +31,13 @@ module.exports = function (grunt) {
 					callback: log
 				}
 			},
+			withColor: {
+				command: 'ls --color=yes',
+				options: {
+					stdout: true,
+					stderr: true
+				}
+			},
 			error: {
 				command: 'ls && exit 1',
 				options: {

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
   },
   "licenses": {
     "type": "MIT"
+  },
+  "dependencies": {
+    "stripcolorcodes": "~0.1.0"
   }
 }

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -1,6 +1,7 @@
 'use strict';
 module.exports = function (grunt) {
 	var exec = require('child_process').exec;
+	var stripColors = require('stripcolorcodes');
 	var _ = grunt.util._;
 
 	grunt.registerMultiTask('shell', 'Run shell commands', function () {
@@ -29,15 +30,25 @@ module.exports = function (grunt) {
 			}
 		});
 
+		var captureOutput = function (child, output) {
+			if (grunt.option('color') === false) {
+				child.on('data', function (data) {
+					output.write(stripColors(data));
+				});
+			} else {
+				child.pipe(output);
+			}
+		};
+
 		grunt.verbose.writeln('Command:', cmd.yellow);
 		grunt.verbose.writeflags(options, 'Options');
 
 		if (options.stdout || grunt.option('verbose')) {
-			cp.stdout.pipe(process.stdout);
+			captureOutput(cp.stdout, process.stdout);
 		}
 
 		if (options.stderr || grunt.option('verbose')) {
-			cp.stderr.pipe(process.stderr);
+			captureOutput(cp.stderr, process.stderr);
 		}
 	});
 };


### PR DESCRIPTION
If grunt was invoked with --no-color, we have a regexp that strips
colors from the child process' output before forwarding it on to
stdout and stderr.
