### PR TITLE
Allow interactive commands to be used

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -202,7 +202,7 @@ The command you want to run or a function which returns it. Supports underscore 
 
 #### stdin
 
-Default: `false`
+Default: `true`
 Type: `Boolean`
 
 Forward the terminal's stdin to the command.

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -9,6 +9,7 @@ module.exports = function (grunt) {
 		var options = this.options({
 			stdout: false,
 			stderr: false,
+			stdin: true,
 			failOnError: false
 		});
 		var cmd = this.data.command;


### PR DESCRIPTION
Connects the parent's stdin to the child process's stdin when the option stdin is set to true
