### PR TITLE
Properly exiting the command

### DIFF
--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -28,7 +28,7 @@ module.exports = function (grunt) {
 				}
 				cb();
 			}
-		}.bind(this));
+		}.bind(this)).on('exit', function(code){ cb(); });
 
 		var captureOutput = function (child, output) {
 			if (grunt.option('color') === false) {


### PR DESCRIPTION
In some cases the callback function is not called by exec. For example, running 'pytest' as a command didn't call the callback. So calling cb() on exit event fixes this.
