### PR TITLE
Updates chalk to 0.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "chalk": "~0.4.0"
+    "chalk": "^0.5.1"
   },
   "devDependencies": {
     "grunt": "~0.4.0"


### PR DESCRIPTION
Ola @sindresorhus, was making my round through `grunt` plugins I use in my own projects and noticed `grunt-shell` still using `chalk@0.4.0`. :wink:
