### PR TITLE
Enable stdin raw mode for tty processes

### DIFF
--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -53,6 +53,7 @@ module.exports = function (grunt) {
 		if (options.stdin) {
 			process.stdin.resume();
 			process.stdin.setEncoding('utf8');
+			process.stdin.setRawMode(true);
 			process.stdin.pipe(cp.stdin);
 		}
 	});


### PR DESCRIPTION
When working on a package, I often use a bash script to open a repl with the package I'm working on pre-loaded. Something like this:

``` bash
#!/usr/bin/env node
var repl = require('repl');

myPackage = require('../myPackage.js');

var r = repl.start({
  terminal: true
});

r.on('exit', function() {
  process.exit();
});
```

This works great, but I'd like to use grunt-shell so I can call my console with `grunt console` instead of `bin/console.js`. The issue is that unless raw mode is enabled, vt100 escape codes aren't passed to the child process, and crucial repl features like history no longer work.

This pull request simply enables raw mode for process.stdin.

Thanks!
