### PR TITLE
Use 'setRawMode' only when defined as a function

### DIFF
--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -53,7 +53,9 @@ module.exports = function (grunt) {
 		if (options.stdin) {
 			process.stdin.resume();
 			process.stdin.setEncoding('utf8');
-			process.stdin.setRawMode(true);
+			if (typeof process.stdin.setRawMode === 'function') {
+				process.stdin.setRawMode(true);
+			}
 			process.stdin.pipe(cp.stdin);
 		}
 	});


### PR DESCRIPTION
In a lot of environments, 'setRawMode' is not defined as a function which breaks grunt execution. Please fix this and create a new package.
