### PR TITLE
There is no default for `callback`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,7 @@ module.exports = function (grunt) {
 					if (version) {
 						return 'echo grunt-shell version: ' + version;
 					} else {
-						return 'echo grunt version: ' + this.version
+						return 'echo grunt version: ' + this.version;
 					}
 				}
 			},

--- a/readme.md
+++ b/readme.md
@@ -218,8 +218,7 @@ This sets `stdin` to [act as a raw device](http://nodejs.org/api/tty.html#tty_rs
 
 ### callback(err, stdout, stderr, cb)
 
-Type: `function`  
-Default: `function () {}`
+Type: `function`
 
 Lets you override the default callback with your own.
 


### PR DESCRIPTION
Also add a missing semicolon