### PR TITLE
add `options.blocking` to make grunt pause until the child process has f...

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -239,6 +239,13 @@ Specify some options to be passed to the [.exec()](http://nodejs.org/api/child_p
 - `maxBuffer` Number *(Default: 200\*1024)*
 - `killSignal` String *(Default: 'SIGTERM')*
 
+### blocking
+
+Type: `boolean`  
+Default: `false`
+
+This makes grunt pauses until the child process has finished.
+
 
 ## License
 

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -10,7 +10,8 @@ module.exports = function (grunt) {
 			stderr: true,
 			stdin: true,
 			failOnError: true,
-			stdinRawMode: false
+			stdinRawMode: false,
+			blocking: false
 		});
 		var cmd = this.data.command;
 
@@ -27,7 +28,9 @@ module.exports = function (grunt) {
 				if (err && options.failOnError) {
 					grunt.warn(err);
 				}
-				cb();
+				if (!options.blocking) {
+					cb();
+				}
 			}
 		}.bind(this));
 
@@ -60,6 +63,14 @@ module.exports = function (grunt) {
 			}
 
 			process.stdin.pipe(cp.stdin);
+		}
+
+		if (options.blocking) {
+			cp.on('exit', function () {
+				cb();
+			}).on('error', function () {
+				cb();
+			});
 		}
 	});
 };


### PR DESCRIPTION
...inished

Use case:
https://github.com/btford/grunt-conventional-changelog/issues/52
User might want to pause until the process has finished then run the next task