### PR TITLE
Add command shorthand

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,9 @@ grunt.initConfig({
 		},
 		target: {
 			command: 'ls'
-		}
+		},
+		// or directly with a string when no extra options are required
+		another: 'ls ./src'
 	}
 });
 
@@ -178,6 +180,8 @@ grunt.initConfig({
 Type: `string`, `function`
 
 The command you want to run or a function which returns it. Supports underscore templates.
+
+*command can be omitted by directly setting the target with the command.*
 
 ## Options
 

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -12,12 +12,7 @@ module.exports = function (grunt) {
 			failOnError: true,
 			stdinRawMode: false
 		});
-		var cmd;
-		if (typeof this.data === 'string')
-			cmd = this.data;
-		else
-			cmd = this.data.command;
-
+		var cmd = typeof this.data === 'string' ? this.data : this.data.command;
 		if (cmd === undefined) {
 			throw new Error('`command` required');
 		}

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -12,7 +12,11 @@ module.exports = function (grunt) {
 			failOnError: true,
 			stdinRawMode: false
 		});
-		var cmd = this.data.command;
+		var cmd;
+		if (typeof this.data === 'string')
+			cmd = this.data;
+		else
+			cmd = this.data.command;
 
 		if (cmd === undefined) {
 			throw new Error('`command` required');


### PR DESCRIPTION
This lets us do shorter hand commands like 
```
shell:
  clone: git clone https://github.com/sindresorhus/grunt-shell
  lint: somelinter ./src/**/*.js
```
Useful when no extra option configuration is required.
This doesn't break the existing way we use this task either