### PR TITLE
fix hangs with CLI commands waiting for input

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -64,6 +64,20 @@ module.exports = grunt => {
 					callback: check('shell.js')
 				}
 			},
+			'waiting-child': {
+				command: 'node waiting-child.js',
+				cwd: 'test',
+				options: {
+					callback: check('')
+				}
+			},
+			'waiting-child-pipe': {
+				command: 'echo abc | node waiting-child.js',
+				cwd: 'test',
+				options: {
+					callback: check('abc')
+				}
+			},
 			fnCmd: {
 				command(version) {
 					// `this` is scoped to the grunt instance

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -72,14 +72,16 @@ module.exports = grunt => {
 		}
 
 		if (opts.stdin) {
-			process.stdin.resume();
 			process.stdin.setEncoding('utf8');
 
 			if (opts.stdinRawMode && process.stdin.isTTY) {
 				process.stdin.setRawMode(true);
 			}
 
-			process.stdin.pipe(cp.stdin);
+			let chunk;
+			while (chunk = process.stdin.read()) cp.stdin.write(chunk);
 		}
+
+		cp.stdin.end();
 	});
 };

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -79,7 +79,9 @@ module.exports = grunt => {
 			}
 
 			let chunk;
-			while (chunk = process.stdin.read()) cp.stdin.write(chunk);
+			while (chunk = process.stdin.read()) { // eslint-disable-line no-cond-assign
+				cp.stdin.write(chunk);
+			}
 		}
 
 		cp.stdin.end();

--- a/test/waiting-child.js
+++ b/test/waiting-child.js
@@ -3,7 +3,9 @@
 let ret = '';
 process.stdin.on('readable', () => {
 	let chunk;
-	while (chunk = process.stdin.read()) ret += chunk;
+	while (chunk = process.stdin.read()) { // eslint-disable-line no-cond-assign
+		ret += chunk;
+	}
 });
 process.stdin.on('end', () => {
 	process.stdout.write(ret);

--- a/test/waiting-child.js
+++ b/test/waiting-child.js
@@ -1,0 +1,10 @@
+'use strict';
+
+let ret = '';
+process.stdin.on('readable', () => {
+	let chunk;
+	while (chunk = process.stdin.read()) ret += chunk;
+});
+process.stdin.on('end', () => {
+	process.stdout.write(ret);
+});


### PR DESCRIPTION
The previous .resume() and .pipe() did not close the stdin stream on the child process which made scripts that wait for data on stdin hang. The fix manually sends all stdin chunks to the child and ensures that the stream is always closed afterwards.

There might be a cleaner solution using flowing mode, but I'm not sure how to ensure closure of the target WriteStream when using `.pipe()`.

This should properly solve these issue:

- https://github.com/sindresorhus/grunt-shell/issues/95
- https://github.com/tjunnone/npm-check-updates/issues/119