### PR TITLE
Allow functions as shorthand commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
-    "xo": "*"
+    "xo": "0.20.3"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -20,7 +20,9 @@ module.exports = grunt => {
 			}
 		});
 
-		let cmd = typeof this.data === 'string' ? this.data : this.data.command;
+		let cmd = typeof this.data === 'string' || typeof this.data === 'function' ?
+			this.data :
+			this.data.command;
 
 		if (cmd === undefined) {
 			throw new Error('`command` required');

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -26,7 +26,7 @@ module.exports = grunt => {
 			throw new Error('`command` required');
 		}
 
-		// increase max buffer
+		// Increase max buffer
 		opts.execOptions = Object.assign({}, opts.execOptions);
 		opts.execOptions.maxBuffer = opts.execOptions.maxBuffer || TEN_MEGABYTES;
 


### PR DESCRIPTION
The documentation declares `command` as being of type string or Function, and states that it can be "omitted by directly setting the target with the command". It made me believe that I could directly pass a function as a target, but this actually only works for strings. This PR allows passing a function as target and omitting `command`.